### PR TITLE
#89 fix Riverpodのプロバイダーの変数名を変更

### DIFF
--- a/lib/config/github_search_app.dart
+++ b/lib/config/github_search_app.dart
@@ -91,8 +91,8 @@ class _GitHubSearchApp extends StatelessWidget {
             name: RepoViewPage.name,
             builder: (context, state) => ProviderScope(
               overrides: [
-                repoDetailViewControllerProvider.overrideWithProvider(
-                  repoDetailViewControllerProviderFamily(
+                repoDetailViewStateProvider.overrideWithProvider(
+                  repoDetailViewStateProviderFamily(
                     RepoDetailViewParameter.from(state),
                   ),
                 ),

--- a/lib/presentation/components/repo/repo_detail_view.dart
+++ b/lib/presentation/components/repo/repo_detail_view.dart
@@ -17,7 +17,7 @@ class RepoDetailView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final asyncValue = ref.watch(repoDetailViewControllerProvider);
+    final asyncValue = ref.watch(repoDetailViewStateProvider);
     return AsyncValueHandler<RepoData>(
       value: asyncValue,
       builder: (data) => _RepoDetailView(data: data),

--- a/lib/presentation/components/repo/repo_detail_view_controller.dart
+++ b/lib/presentation/components/repo/repo_detail_view_controller.dart
@@ -11,14 +11,14 @@ import '../../../entities/repo/repo_data.dart';
 import '../../../repositories/repo_repository.dart';
 import '../../../utils/logger.dart';
 
-/// リポジトリ詳細Viewコントローラープロバイダー
-final repoDetailViewControllerProvider = StateNotifierProvider.autoDispose<
+/// リポジトリ詳細View状態プロバイダー
+final repoDetailViewStateProvider = StateNotifierProvider.autoDispose<
     RepoDetailViewController, AsyncValue<RepoData>>(
   (ref) => throw StateError('Provider was not initialized'),
 );
 
-/// リポジトリ詳細Viewコントローラープロバイダー（Family）
-final repoDetailViewControllerProviderFamily = StateNotifierProvider.family
+/// リポジトリ詳細View状態プロバイダー（Family）
+final repoDetailViewStateProviderFamily = StateNotifierProvider.family
     .autoDispose<RepoDetailViewController, AsyncValue<RepoData>,
         RepoDetailViewParameter>(
   (ref, parameter) {

--- a/lib/presentation/components/repo/repo_list_view.dart
+++ b/lib/presentation/components/repo/repo_list_view.dart
@@ -19,7 +19,7 @@ class RepoListView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final asyncValue = ref.watch(repoListViewControllerProvider);
+    final asyncValue = ref.watch(repoListViewStateProvider);
     return AsyncValueHandler<RepoListViewState>(
       value: asyncValue,
       builder: (state) => _RepoListView(state: state),
@@ -68,7 +68,7 @@ class _CircularProgressListTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final controller = ref.watch(repoListViewControllerProvider.notifier);
+    final controller = ref.watch(repoListViewStateProvider.notifier);
     return VisibilityDetector(
       key: const Key('for detect visibility'),
       child: Column(

--- a/lib/presentation/components/repo/repo_list_view_controller.dart
+++ b/lib/presentation/components/repo/repo_list_view_controller.dart
@@ -12,8 +12,8 @@ import 'repo_search_repos_order.dart';
 import 'repo_search_repos_query.dart';
 import 'repo_search_repos_sort.dart';
 
-/// リポジトリ一覧Viewコントローラープロバイダー
-final repoListViewControllerProvider = StateNotifierProvider.autoDispose<
+/// リポジトリ一覧View状態プロバイダー
+final repoListViewStateProvider = StateNotifierProvider.autoDispose<
     RepoListViewController, AsyncValue<RepoListViewState>>(
   (ref) {
     final reposRepository = ref.watch(repoRepositoryProvider);

--- a/lib/presentation/components/repo/repo_order_toggle_button.dart
+++ b/lib/presentation/components/repo/repo_order_toggle_button.dart
@@ -18,7 +18,7 @@ class RepoOrderToggleButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     // リポジトリ検索の実行中やエラー時はトグルボタンを無効化する
-    final asyncValue = ref.watch(repoListViewControllerProvider);
+    final asyncValue = ref.watch(repoListViewStateProvider);
     return asyncValue.when(
       data: (state) => const RepoOrderToggleButtonInternal(),
       error: (_, __) => const RepoOrderToggleButtonInternal(

--- a/test/presentation/pages/repo/repo_view_page_test.dart
+++ b/test/presentation/pages/repo/repo_view_page_test.dart
@@ -15,8 +15,8 @@ void main() {
       await tester.pumpWidget(
         mockGitHubSearchApp(
           overrides: [
-            repoDetailViewControllerProvider.overrideWithProvider(
-              repoDetailViewControllerProviderFamily(
+            repoDetailViewStateProvider.overrideWithProvider(
+              repoDetailViewStateProviderFamily(
                 const RepoDetailViewParameter(
                   ownerName: 'flutter',
                   repoName: 'plugins',

--- a/test/presentation/widgets/repo/repo_detail_view_controller_test.dart
+++ b/test/presentation/widgets/repo/repo_detail_view_controller_test.dart
@@ -20,7 +20,7 @@ void main() {
       // ignore: prefer_function_declarations_over_variables
       final func = () {
         try {
-          container.read(repoDetailViewControllerProvider);
+          container.read(repoDetailViewStateProvider);
         } on ProviderException catch (e) {
           // ignore: only_throw_errors
           throw (e.exception as ProviderException).exception;
@@ -31,15 +31,15 @@ void main() {
     test('overridesすればStateErrorをthrowしないはず', () async {
       final container = mockProviderContainer(
         overrides: [
-          repoDetailViewControllerProvider.overrideWithProvider(
-            repoDetailViewControllerProviderFamily(repoDetailViewParameter),
+          repoDetailViewStateProvider.overrideWithProvider(
+            repoDetailViewStateProviderFamily(repoDetailViewParameter),
           ),
         ],
       );
       // ignore: prefer_function_declarations_over_variables
       final func = () {
         try {
-          container.read(repoDetailViewControllerProvider);
+          container.read(repoDetailViewStateProvider);
         } on ProviderException catch (e) {
           // ignore: only_throw_errors
           throw (e.exception as ProviderException).exception;
@@ -52,14 +52,14 @@ void main() {
     test('Controllerを生成するとリポジトリエンティティを取得するはず', () async {
       final container = mockProviderContainer(
         overrides: [
-          repoDetailViewControllerProvider.overrideWithProvider(
-            repoDetailViewControllerProviderFamily(repoDetailViewParameter),
+          repoDetailViewStateProvider.overrideWithProvider(
+            repoDetailViewStateProviderFamily(repoDetailViewParameter),
           ),
         ],
       );
       final controller = container
           .listen(
-            repoDetailViewControllerProvider.notifier,
+            repoDetailViewStateProvider.notifier,
             (previous, next) {},
           )
           .read();

--- a/test/presentation/widgets/repo/repo_list_view_controller_test.dart
+++ b/test/presentation/widgets/repo/repo_list_view_controller_test.dart
@@ -18,7 +18,7 @@ void main() {
     tmpDir = await openAppDataBox();
     controller = mockProviderContainer()
         .listen(
-          repoListViewControllerProvider.notifier,
+          repoListViewStateProvider.notifier,
           (previous, next) {},
         )
         .read();


### PR DESCRIPTION
例：
repoDetailViewControllerProvider => repoDetailViewStateProvider
ref.watch(repoDetailViewStateProvider) で取得できるのは State で
ref.watch(repoDetailViewStateProvider.notifier) で取得できるのは Controller なので、変更後の方がしっくりくるため。