### PR TITLE
🐛 fix: enum の name プロパティの上書き宣言を止めた

### DIFF
--- a/bin/flutter_test
+++ b/bin/flutter_test
@@ -17,8 +17,7 @@ echo 'Removed coverage dir'
 
 # テストを実行する
 echo 'Testing github-search...'
-#【暫定的にコメントアウト】fvm flutter test --no-test-assets --coverage --machine > test-report.log
-fvm flutter test --no-test-assets --machine > test-report.log
+fvm flutter test --no-test-assets --coverage --machine > test-report.log
 if [ $? -gt 0 ]; then
   # flutter test でエラーがあれば結果を表示して処理終了
   fvm flutter pub global run dart_dot_reporter test-report.log --show-message
@@ -27,13 +26,13 @@ fi
 echo 'Tests done!'
 
 # カバレッジから不要な結果を削除する
-#【暫定的にコメントアウト】lcov --remove coverage/lcov.info 'lib/utils/assets/*' 'lib/localizations/*' -o coverage/lcov.info
+lcov --remove coverage/lcov.info 'lib/utils/assets/*' 'lib/localizations/*' -o coverage/lcov.info
 
 # カバレッジ結果のHTMLを出力する
-#【暫定的にコメントアウト】genhtml coverage/lcov.info -o coverage/html
+genhtml coverage/lcov.info -o coverage/html
 
 # テスト結果をコンソールに表示する
 fvm flutter pub global run dart_dot_reporter test-report.log --show-message
 
 # カバレッジ結果を表示する
-#【暫定的にコメントアウト】open coverage/html/index.html
+open coverage/html/index.html

--- a/lib/repositories/github/api.dart
+++ b/lib/repositories/github/api.dart
@@ -42,8 +42,8 @@ class GitHubApi {
       parametersBuilder: () {
         return {
           'q': query,
-          if (sort != null) 'sort': sort.name,
-          if (order != null) 'order': order.name,
+          if (sort != null) 'sort': sort.jsonName,
+          if (order != null) 'order': order.jsonName,
           if (perPage != null) 'per_page': '$perPage',
           if (page != null) 'page': '$page',
         };
@@ -70,9 +70,9 @@ enum GitHubRepoSearchReposSort {
   forks('forks'),
   helpWantedIssues('help-wanted-issues');
 
-  const GitHubRepoSearchReposSort(this.name);
+  const GitHubRepoSearchReposSort(this.jsonName);
 
-  final String name;
+  final String jsonName;
 
   /// RepoSearchReposSort => GitHubRepoSearchReposSort?
   static GitHubRepoSearchReposSort? valueOf(RepoSearchReposSort sort) {
@@ -91,8 +91,12 @@ enum GitHubRepoSearchReposSort {
 
 /// GitHub リポジトリ検索用オーダー
 enum GitHubRepoSearchReposOrder {
-  desc,
-  asc;
+  desc('desc'),
+  asc('asc');
+
+  const GitHubRepoSearchReposOrder(this.jsonName);
+
+  final String jsonName;
 
   /// RepoSearchReposOrder => GitHubRepoSearchReposOrder
   static GitHubRepoSearchReposOrder valueOf(

--- a/test/repositories/github/api_test.dart
+++ b/test/repositories/github/api_test.dart
@@ -127,15 +127,15 @@ void main() {
     });
   });
   group('GitHubRepoSearchReposSort', () {
-    test('stars.name', () {
-      expect(GitHubRepoSearchReposSort.stars.name, 'stars');
+    test('stars.jsonName', () {
+      expect(GitHubRepoSearchReposSort.stars.jsonName, 'stars');
     });
-    test('forks.name', () {
-      expect(GitHubRepoSearchReposSort.forks.name, 'forks');
+    test('forks.jsonName', () {
+      expect(GitHubRepoSearchReposSort.forks.jsonName, 'forks');
     });
-    test('helpWantedIssues.name', () {
+    test('helpWantedIssues.jsonName', () {
       expect(
-        GitHubRepoSearchReposSort.helpWantedIssues.name,
+        GitHubRepoSearchReposSort.helpWantedIssues.jsonName,
         'help-wanted-issues',
       );
     });
@@ -173,11 +173,11 @@ void main() {
     });
   });
   group('GitHubRepoSearchReposOrder', () {
-    test('desc.name', () {
-      expect(GitHubRepoSearchReposOrder.desc.name, 'desc');
+    test('desc.jsonName', () {
+      expect(GitHubRepoSearchReposOrder.desc.jsonName, 'desc');
     });
-    test('asc.name', () {
-      expect(GitHubRepoSearchReposOrder.asc.name, 'asc');
+    test('asc.jsonName', () {
+      expect(GitHubRepoSearchReposOrder.asc.jsonName, 'asc');
     });
     test('valueOf(desc)', () {
       expect(


### PR DESCRIPTION
- enum の name プロパティを上書き宣言すると `flutter test --coverage` でエラーが発生するため
- 下記 Issue でも報告されている

Issue #116
Issue https://github.com/flutter/flutter/issues/103656